### PR TITLE
Split comment-on-linter-error.yml into two workflows for security rea…

### DIFF
--- a/.github/workflows/check-linter-error.yml
+++ b/.github/workflows/check-linter-error.yml
@@ -1,0 +1,51 @@
+name: Check lint failure
+
+on:
+  pull_request:
+    types:
+      - opened
+    branches:
+      - $default-branch
+
+concurrency:
+  group: ${{github.workflow}}-${{github.ref}}
+  cancel-in-progress: true
+
+jobs:
+  comment_on_lint_failure:
+    name: Comment on lint failure
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          ref: "refs/pull/${{ github.event.number }}/merge"
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          cache: yarn
+      - name: Install
+        run: yarn --frozen-lockfile
+      - name: Build
+        run: yarn build
+      - name: lint
+        run: yarn lint
+      - name: Check dependency versions
+        run: node scripts/check-dependencies.js
+      - name: Install website
+        working-directory: docs/
+        run: yarn
+      - name: Lint website
+        working-directory: docs/
+        run: yarn lint
+      - name: Save PR number
+        if: ${{ failure() }}
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.number }} > ./pr/NR
+      - uses: actions/upload-artifact@v4
+        if: ${{ failure() }}
+        with:
+          name: pr
+          path: pr/
+	  retention-days: 1

--- a/.github/workflows/check-linter-error.yml
+++ b/.github/workflows/check-linter-error.yml
@@ -48,4 +48,4 @@ jobs:
         with:
           name: pr
           path: pr/
-	  retention-days: 1
+          retention-days: 1

--- a/.github/workflows/check-linter-error.yml
+++ b/.github/workflows/check-linter-error.yml
@@ -1,4 +1,4 @@
-name: Check lint failure
+name: Check Lint Failure
 
 on:
   pull_request:
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  comment_on_lint_failure:
+  check_lint_failure:
     name: Comment on lint failure
     runs-on: ubuntu-latest
     steps:
@@ -42,10 +42,9 @@ jobs:
         if: ${{ failure() }}
         run: |
           mkdir -p ./pr
-          echo ${{ github.event.number }} > ./pr/NR
+          echo ${{ github.event.number }} > ./pr/pr-number
       - uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
-          name: pr
-          path: pr/
-          retention-days: 1
+          name: pr-number
+          path: pr/pr-number

--- a/.github/workflows/comment-on-linter-error.yml
+++ b/.github/workflows/comment-on-linter-error.yml
@@ -4,12 +4,12 @@ name: Comment on the pull request
 # access to secrets
 on:
   workflow_run:
-    workflows: ["Check lint failure"]
+    workflows: ["Check Lint Failure"]
     types:
       - completed
 
 jobs:
-  upload:
+  comment_on_lint_failure:
     runs-on: ubuntu-latest
     if: >
       github.event.workflow_run.event == 'pull_request' &&
@@ -18,18 +18,24 @@ jobs:
       - name: 'Download artifact'
         uses: actions/download-artifact@v4
         with:
-          name: pr
-          path: pr/
-
+          name: pr-number
+          path: pr
+          repository: ${{ github.repository }}
+          run-id: ${{github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Display structure of downloaded files
+        run: ls -R pr
+      - name: Catfile
+        run: cat pr/pr-number
       - name: 'Comment on PR'
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             var fs = require('fs');
-            var issue_number = Number(fs.readFileSync('./pr/NR'));
+            var issue_number = Number(fs.readFileSync('pr/pr-number'));
             github.rest.issues.createComment({
-              issue_number: context.issue.number,
+              issue_number: issue_number,
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: "Thanks for submitting this PR!\n\nUnfortunately, it has some linter errors, so we can't merge it yet. Can you please fix them?\n\nRunning yarn `lint:fix` in the root of the repository may fix them automatically."

--- a/.github/workflows/comment-on-linter-error.yml
+++ b/.github/workflows/comment-on-linter-error.yml
@@ -1,48 +1,33 @@
-name: Comment on lint failure
+name: Comment on the pull request
 
+# read-write repo token
+# access to secrets
 on:
-  pull_request_target:
+  workflow_run:
+    workflows: ["Check lint failure"]
     types:
-      - opened
-    branches:
-      - $default-branch
-
-concurrency:
-  group: ${{github.workflow}}-${{github.ref}}
-  cancel-in-progress: true
+      - completed
 
 jobs:
-  comment_on_lint_failure:
-    name: Comment on lint failure
+  upload:
     runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'failure'
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
+      - name: 'Download artifact'
+        uses: actions/download-artifact@v4
         with:
-          ref: "refs/pull/${{ github.event.number }}/merge"
-      - uses: actions/setup-node@v2
+          name: pr
+          path: pr/
+
+      - name: 'Comment on PR'
+        uses: actions/github-script@v6
         with:
-          node-version: 14
-          cache: yarn
-      - name: Install
-        run: yarn --frozen-lockfile
-      - name: Build
-        run: yarn build
-      - name: lint
-        run: yarn lint
-      - name: Check dependency versions
-        run: node scripts/check-dependencies.js
-      - name: Install website
-        working-directory: docs/
-        run: yarn
-      - name: Lint website
-        working-directory: docs/
-        run: yarn lint
-      - uses: actions/github-script@v6
-        name: Comment on failure
-        if: ${{ failure() }}
-        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            var fs = require('fs');
+            var issue_number = Number(fs.readFileSync('./pr/NR'));
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,


### PR DESCRIPTION
…sons

Using pull_request_target while also using actions/checkout to pull the pull request code opens up the possibility of remote code execution, as pull_request_target gives write access on the repository. Since write access is required to access the github token and comment on the PR, this puts the actual code build into a workflow that uses the safer pull_request trigger, uploads the artifact to github, and then triggers a second workflow_run triggered workflow that has write access and is able to comment on the PR.

This needs to be tested to make sure it won't cause any problems

<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
